### PR TITLE
Integrate deuda view with API

### DIFF
--- a/src/app/core/services/package.service.ts
+++ b/src/app/core/services/package.service.ts
@@ -28,29 +28,48 @@ export interface Promotion {
   scope: 'package' | 'city' | 'colony' | 'service';
 }
 
+export interface MonthlyDebt {
+  Mes: string;
+  PrecioSinDescuento: number;
+  PrecioAplicado: number;
+  EstadoPromocion: string;
+}
+
+export interface DebtDetail {
+  nombre: string;
+  Colonia: string;
+  Paquete: string;
+  Servicios: string[];
+  Promocion: string;
+  mensualidades: MonthlyDebt[];
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class PackageService {
-  // URLs base de la API (reemplazar)
-  private packagesUrl = 'https://tu-api.com/api/packages';
-  private subscribersUrl = 'https://tu-api.com/api/subscribers';
-  private promotionsUrl = 'https://tu-api.com/api/promotions';
+  // URL base de la API local
+  private apiBase = 'http://localhost:5222/api';
 
   constructor(private http: HttpClient) {}
 
   // Obtener paquetes disponibles desde API
   getPackages(): Observable<Package[]> {
-    return this.http.get<Package[]>(this.packagesUrl);
+    return this.http.get<Package[]>(`${this.apiBase}/PaquetesDatas`);
   }
 
-  // Obtener suscriptores desde API
+  // Obtener suscriptores con detalle
   getSubscribers(): Observable<Subscriber[]> {
-    return this.http.get<Subscriber[]>(this.subscribersUrl);
+    return this.http.get<Subscriber[]>(`${this.apiBase}/SuscriptorDatas/suscriptorInfo`);
   }
 
-  // Obtener promociones aplicables según suscriptor y paquete
-  getPromotions(packageId: number, subscriberId: number): Observable<Promotion[]> {
-    return this.http.get<Promotion[]>(`${this.promotionsUrl}?packageId=${packageId}&subscriberId=${subscriberId}`);
+  // Obtener reporte de un suscriptor
+  getSubscriberReport(id: number): Observable<DebtDetail[]> {
+    return this.http.get<DebtDetail[]>(`${this.apiBase}/SuscriptorDatas/reporte-suscriptor/${id}`);
+  }
+
+  // Obtener deuda calculada por suscriptor
+  getDebtBySubscriber(id: number): Observable<DebtDetail[]> {
+    return this.http.get<DebtDetail[]>(`${this.apiBase}/SuscriptorDatas/reporte-suscriptor/${id}/deuda`);
   }
 }

--- a/src/app/pages/deuda-suscriptor/deuda-suscriptor.component.html
+++ b/src/app/pages/deuda-suscriptor/deuda-suscriptor.component.html
@@ -16,51 +16,28 @@
 
       <mat-form-field *ngIf="selectedSubscriberId" appearance="fill" class="form-field">
         <mat-label>Selecciona Paquete</mat-label>
-        <mat-select [(ngModel)]="selectedPackageId" (selectionChange)="onSelectPackage()">
+        <mat-select [(ngModel)]="selectedPackageIndex" (selectionChange)="onSelectPackage()">
           <mat-option [value]="null" disabled>Selecciona</mat-option>
-          <mat-option *ngFor="let pkg of packages" [value]="pkg.id">{{ pkg.name }}</mat-option>
+          <mat-option *ngFor="let pkg of debtPackages; let i = index" [value]="i">{{ pkg.Paquete }}</mat-option>
         </mat-select>
       </mat-form-field>
     </div>
 
     <!-- 2. Detalles del paquete -->
-    <div *ngIf="selectedPackage" class="package-details">
+    <div *ngIf="selectedDebt" class="package-details">
       <h3>Detalles del Paquete</h3>
-      <p><strong>{{ selectedPackage.description }}</strong></p>
-      <p><strong>Precio:</strong> {{ selectedPackage.price | currency:'MXN':'symbol':'1.0-0' }}</p>
+      <p><strong>{{ selectedDebt.Paquete }}</strong></p>
+      <p><strong>Precio:</strong> {{ selectedDebt.mensualidades[0].PrecioSinDescuento | currency:'MXN':'symbol':'1.0-0' }}</p>
 
       <!-- Servicios con chips -->
       <h4>Servicios incluidos</h4>
       <mat-chip-list>
-        <mat-chip *ngFor="let svc of selectedPackage.services" selectable="false" removable="false">
+        <mat-chip *ngFor="let svc of selectedDebt.Servicios" selectable="false" removable="false">
           {{ svc }}: {{ serviceShare | currency:'MXN':'symbol':'1.2-2' }} / mes
         </mat-chip>
       </mat-chip-list>
     </div>
-
-    <!-- 3. Promociones -->
-    <div *ngIf="selectedPackage">
-      <h3>Promociones Disponibles</h3>
-      <ul class="promo-list">
-        <li *ngFor="let promo of promotions" class="promo-item">
-          <button mat-stroked-button color="accent" disabled>
-            {{ promo.description }}
-            ({{ promo.discountType === 'percentage' ? promo.value + '%' : ('$' + promo.value) }})
-          </button>
-        </li>
-      </ul>
-
-      <h3>Promociones Aplicadas</h3>
-      <ul class="promo-list">
-        <li *ngFor="let promo of appliedPromotions" class="promo-item">
-          <button mat-flat-button color="primary">
-            {{ promo.description }}
-            ({{ promo.discountType === 'percentage' ? promo.value + '%' : ('$' + promo.value) }})
-          </button>
-        </li>
-        <li *ngIf="appliedPromotions.length === 0" class="no-promos">Ninguna promoción aplicada.</li>
-      </ul>
-    </div>
+    
 
     <!-- 4. Barra de ahorro -->
     <div *ngIf="calculatedTotal !== null" class="savings-section">
@@ -69,7 +46,7 @@
     </div>
 
     <!-- 5. Total general y pagos -->
-    <div *ngIf="selectedPackage" class="total-container">
+    <div *ngIf="selectedDebt" class="total-container">
       <h3>Total a pagar con meses en promoción</h3>
       <p class="total-amount">
         {{ calculatedTotal !== null

--- a/src/app/pages/deuda-suscriptor/deuda-suscriptor.component.ts
+++ b/src/app/pages/deuda-suscriptor/deuda-suscriptor.component.ts
@@ -7,7 +7,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatChipsModule } from '@angular/material/chips';
-import { PackageService, Package, Subscriber, Promotion } from '../../core/services/package.service';
+import { PackageService, DebtDetail, Subscriber } from '../../core/services/package.service';
 
 interface MonthlyPayment {
   month: string;
@@ -33,14 +33,12 @@ interface MonthlyPayment {
 export class DeudaSuscriptorComponent implements OnInit {
   // Datos obtenidos desde el servicio
   subscribers: Subscriber[] = [];
-  packages: Package[] = [];
-  promotions: Promotion[] = [];
-  appliedPromotions: Promotion[] = [];
+  debtPackages: DebtDetail[] = [];
 
   // Selecciones actuales
   selectedSubscriberId: number | null = null;
-  selectedPackageId: number | null = null;
-  selectedPackage: Package | null = null;
+  selectedPackageIndex: number | null = null;
+  selectedDebt: DebtDetail | null = null;
 
   // Resultados del cálculo de deuda
   calculatedTotal: number | null = null;
@@ -62,7 +60,6 @@ export class DeudaSuscriptorComponent implements OnInit {
 
   ngOnInit() {
     this.loadSubscribers();
-    this.loadPackages();
   }
 
   // Cargar suscriptores desde el servicio
@@ -73,69 +70,42 @@ export class DeudaSuscriptorComponent implements OnInit {
     });
   }
 
-  // Cargar paquetes desde el servicio
-  private loadPackages() {
-    this.packageService.getPackages().subscribe({
-      next: (data: Package[]) => this.packages = data,
-      error: (err: unknown) => console.error('Error al cargar paquetes:', err)
-    });
-  }
 
-  // Cambiar de suscriptor limpia las selecciones
+
+  // Cambiar de suscriptor: cargar paquetes con deuda
   onSelectSubscriber() {
     this.resetAll();
-  }
-
-  // Al seleccionar paquete, cargar promociones desde API
-  onSelectPackage() {
-    this.selectedPackage = this.packages.find(p => p.id === this.selectedPackageId) ?? null;
-    this.resetTotals();
-
-    if (this.selectedPackage && this.selectedSubscriberId) {
-      this.packageService.getPromotions(this.selectedPackage.id, this.selectedSubscriberId).subscribe({
-        next: (promos: Promotion[]) => {
-          this.promotions = promos;
-          this.appliedPromotions = promos.filter(p => p.autoApplied);
+    if (this.selectedSubscriberId) {
+      this.packageService.getDebtBySubscriber(this.selectedSubscriberId).subscribe({
+        next: (data: DebtDetail[]) => {
+          this.debtPackages = data;
         },
-        error: (err: unknown) => console.error('Error al cargar promociones:', err)
+        error: (err: unknown) => console.error('Error al cargar deuda:', err)
       });
     }
   }
 
-  // Calcular el total a pagar, aplicar promociones y dividir en meses
+  // Al seleccionar paquete se calculan los totales
+  onSelectPackage() {
+    this.selectedDebt = this.selectedPackageIndex !== null ? this.debtPackages[this.selectedPackageIndex] : null;
+    this.calculateTotal();
+  }
+
+  // Calcular el total a pagar basándose en la deuda recibida
   calculateTotal() {
-    if (!this.selectedPackage) return;
+    this.resetTotals();
+    if (!this.selectedDebt) return;
 
-    const base = this.selectedPackage.price;
-    let total = base;
-
-    this.appliedPromotions.forEach(promo => {
-      total -= promo.discountType === 'percentage'
-        ? (promo.value / 100) * base
-        : promo.value;
-    });
-
-    this.calculatedTotal = Math.max(0, Math.round(total));
-    this.discountPercentage = Math.round(((base - this.calculatedTotal) / base) * 100);
-    this.promotionMonths = Math.min(this.selectedPackage.promotionMonths, 12);
-
-    const share = this.promotionMonths > 0
-      ? +(this.calculatedTotal / this.promotionMonths).toFixed(2)
-      : 0;
-
-    // Generar lista de pagos mensuales con nombre del mes
+    const baseTotal = this.selectedDebt.mensualidades.reduce((a, m) => a + m.PrecioSinDescuento, 0);
+    const appliedTotal = this.selectedDebt.mensualidades.reduce((a, m) => a + m.PrecioAplicado, 0);
+    this.calculatedTotal = appliedTotal;
+    this.discountPercentage = Math.round(((baseTotal - appliedTotal) / baseTotal) * 100);
+    this.promotionMonths = this.selectedDebt.mensualidades.length;
+    this.monthlyPayments = this.selectedDebt.mensualidades.map(m => ({ month: m.Mes, amount: m.PrecioAplicado }));
     const startMonthIndex = new Date().getMonth();
-    this.monthlyPayments = [];
-    for (let i = 0; i < this.promotionMonths; i++) {
-      const monthName = this.monthNames[(startMonthIndex + i) % 12];
-      this.monthlyPayments.push({ month: monthName, amount: share });
-    }
-
     this.nextMonthName = this.monthNames[(startMonthIndex + this.promotionMonths) % 12];
-    this.postPromotionPayment = base;
-    this.serviceShare = this.promotionMonths > 0
-      ? +(share / this.selectedPackage.services.length).toFixed(2)
-      : 0;
+    this.postPromotionPayment = this.selectedDebt.mensualidades[0].PrecioSinDescuento;
+    this.serviceShare = this.selectedDebt.Servicios.length > 0 ? +(this.selectedDebt.mensualidades[0].PrecioAplicado / this.selectedDebt.Servicios.length).toFixed(2) : 0;
   }
 
   // Generar PDF con resumen
@@ -145,24 +115,17 @@ export class DeudaSuscriptorComponent implements OnInit {
     doc.setFontSize(14);
     doc.text('Resumen de Deuda', 10, 10);
     doc.text(`Suscriptor: ${this.subscribers.find(s => s.id === this.selectedSubscriberId)?.name}`, 10, 20);
-    doc.text(`Paquete: ${this.selectedPackage?.name}`, 10, 30);
-    doc.text(`Precio base: $${this.selectedPackage?.price}`, 10, 40);
-    doc.text('Promociones aplicadas:', 10, 50);
-    let y = 60;
-    this.appliedPromotions.forEach(p => {
-      doc.text(`- ${p.description}`, 12, y);
-      y += 8;
-    });
-    doc.text(`Total a pagar: $${this.calculatedTotal}`, 10, y + 10);
+    doc.text(`Paquete: ${this.selectedDebt?.Paquete}`, 10, 30);
+    doc.text(`Precio base: $${this.selectedDebt?.mensualidades[0].PrecioSinDescuento}`, 10, 40);
+    doc.text(`Total a pagar: $${this.calculatedTotal}`, 10, 50);
     doc.save('deuda-suscriptor.pdf');
   }
 
   // Limpiar selecciones cuando cambia suscriptor
   private resetAll() {
-    this.selectedPackageId = null;
-    this.selectedPackage = null;
-    this.promotions = [];
-    this.appliedPromotions = [];
+    this.selectedPackageIndex = null;
+    this.selectedDebt = null;
+    this.debtPackages = [];
     this.resetTotals();
   }
 


### PR DESCRIPTION
## Summary
- centralize HTTP calls in `package.service.ts`
- call `SuscriptorDatasController` from deuda view
- refactor `DeudaSuscriptorComponent` to use new debt methods

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686362ce45f88322beb96e9efb1e8ea0